### PR TITLE
Fix missing colors in reporting-status page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,3 +105,6 @@ plugins:
 # Use a remote Jekyll theme.
 remote_theme: open-sdg/open-sdg@0.5.0
 goal_image_base: https://open-sdg.github.io/sdg-translations/assets/img/goals
+
+custom_css:
+  - /assets/css/custom.css

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -89,3 +89,6 @@ plugins:
 
 # Use a remote Jekyll theme.
 remote_theme: open-sdg/open-sdg@0.1.0
+
+custom_css:
+  - /assets/css/custom.css

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1,0 +1,11 @@
+---
+---
+.notstarted {
+   background-color: #E27874;
+ }
+.inprogress {
+   background-color: #f0ad4e;
+ }
+.complete {
+   background-color: #5cb85c;
+ }


### PR DESCRIPTION
Hi @JustusCas this addresses the missing colors you might have noticed on the status report page, after upgrading to 0.5.0.

Note that this also adds a "custom.scss" file, which may in general be a better place to put custom CSS, so that you don't have to override the default.scss file.

Note also that this turned up another regression bug in Open SDG, which I've mentioned [here](https://github.com/open-sdg/sdg-build/issues/26). This manifests on your site as the overall bar graph ("57% / 1% / 43$%) wrapping to two lines.