### PR TITLE
Temporarily use latest Open SDG code

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -103,7 +103,7 @@ plugins:
   - jekyll-open-sdg-plugins
 
 # Use a remote Jekyll theme.
-remote_theme: open-sdg/open-sdg@0.6.3
+remote_theme: open-sdg/open-sdg
 goal_image_base: https://open-sdg.github.io/sdg-translations/assets/img/goals
 
 custom_css:


### PR DESCRIPTION
There are some fixes in the latest code. Normally it is best to use a "tag" (like 0.6.3) but in order to address some recently-fixed bugs, it would be OK to use the latest code until a new tag is released.

The bugs that this should fix include:
* Disaggregation filters not displaying in English
* Better support for zero values (eg, 5.3.1)
* Readability in high-contrast on goal pages
* The units-of-measurement in the Y axis getting translated

After the next tag is released (like 0.6.4 or 0.7.0) we can switch to using that.